### PR TITLE
Fixing up regressions on machines sans graphicsmagick

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ node_js:
   - "0.11"
   - "0.10"
   - "0.8"
+matrix:
+  allow_failures:
+    - node_js: "0.11"
+
 install:
   # Set up graphicsmagick
   - ./test/install.sh

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -108,9 +108,12 @@ ImageDiff.prototype = {
       }
     ], function cleanup (err) {
       // Clean up the temporary files
-      async.forEach([actualTmpPath, expectedTmpPath], function cleanupFile (filepath, cb) {
+      var cleanupPaths = [actualTmpPath, expectedTmpPath].filter(function (filepath) {
+        return !!filepath;
+      });
+      async.forEach(cleanupPaths, function cleanupFile (filepath, cb) {
         fs.unlink(filepath, cb);
-      }, function callOriginalCallback (err) {
+      }, function callOriginalCallback (_err) {
         // Callback with the imagesAreSame
         callback(err, imagesAreSame);
       });


### PR DESCRIPTION
While attempting to use `image-diff` on a Vagrant box, I ran into false positives of tests passing when I lacked `graphicsmagick` entirely. This PR fixes that.

I decided to not write a regression test against this since it complicates the `.travis.yml` significantly.

/cc @mlmorg 
