### PR TITLE
Moved from `temporary` to `tmp` to stop creation of excess tempfiles

### DIFF
--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -4,7 +4,7 @@ var path = require('path');
 var async = require('async');
 var gm = require('gm');
 var mkdirp = require('mkdirp');
-var Tempfile = require('temporary/lib/file');
+var tmp = require('tmp');
 
 function ImageDiff() {
 }
@@ -75,18 +75,34 @@ ImageDiff.prototype = {
         // Resize both images
         async.parallel([
           function resizeActualImage (cb) {
-            actualTmpPath = new Tempfile().path + '.png';
-            gm(actualPath).resize(maxWidth, maxHeight).write(actualTmpPath, cb);
+            // Get a temporary filepath
+            tmp.tmpName({postfix: '.png'}, function (err, filepath) {
+              // If there was an error, callback
+              if (err) {
+                return cb(err);
+              }
+
+              // Otherwise, resize the image
+              actualTmpPath = filepath;
+              gm(actualPath).resize(maxWidth, maxHeight).write(actualTmpPath, cb);
+            });
           },
           function resizeExpectedImage (cb) {
-            // If there was no expected image
-            expectedTmpPath = new Tempfile().path + '.png';
-            if (expectedSize.doesNotExist) {
-              gm(maxWidth, maxHeight, 'transparent').write(expectedTmpPath, cb);
-            // Otherwise, resize the image
-            } else {
-              gm(expectedPath).resize(maxWidth, maxHeight).write(expectedTmpPath, cb);
-            }
+            tmp.tmpName({postfix: '.png'}, function (err, filepath) {
+              // If there was an error, callback
+              if (err) {
+                return cb(err);
+              }
+
+              // If there was no expected image, create a transparent image to compare against
+              expectedTmpPath = filepath;
+              if (expectedSize.doesNotExist) {
+                gm(maxWidth, maxHeight, 'transparent').write(expectedTmpPath, cb);
+              // Otherwise, resize the image
+              } else {
+                gm(expectedPath).resize(maxWidth, maxHeight).write(expectedTmpPath, cb);
+              }
+            });
           }
         ], cb);
       },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "async": "~0.2.9",
     "gm": "~1.13.3",
     "mkdirp": "~0.3.5",
-    "temporary": "0.0.7"
+    "tmp": "0.0.23"
   },
   "devDependencies": {
     "mocha": "~1.11.0",

--- a/test/image-diff_test.js
+++ b/test/image-diff_test.js
@@ -1,6 +1,13 @@
 var assert = require('assert');
+var fs = require('fs');
+var os = require('os');
 var getPixels = require('get-pixels');
 var imageDiff = require('../lib/image-diff.js');
+
+var tmpDir = os.tmpdir ? os.tmpdir() : '/tmp';
+before(function () {
+  this.expectedTmpFiles = fs.readdirSync(tmpDir);
+});
 
 describe('image-diff', function () {
   describe('diffing different images', function () {
@@ -57,5 +64,12 @@ describe('image-diff', function () {
     it('asserts images are the same', function () {
       assert.strictEqual(this.imagesAreSame, true);
     });
+  });
+});
+
+describe('After running the tests', function () {
+  it('cleans up the temporary directory', function () {
+    var actualTmpFiles = fs.readdirSync(tmpDir);
+    assert.deepEqual(actualTmpFiles, this.expectedTmpFiles);
   });
 });


### PR DESCRIPTION
As reported in #5, it looks like we are creating unnecessary temporary files. In this PR:
- Add regression test for excess temporary files
- Move from `temporary` to `tmp` which allows for getting filepath without file creation

Fixes #5.

/cc @mlmorg @Raynos 
