### PR TITLE
Added shell quoting for exec calls and assertions for options/files

### DIFF
--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var async = require('async');
 var gm = require('gm');
+var shellQuote = require('shell-quote');
 var mkdirp = require('mkdirp');
 var tmp = require('tmp');
 
@@ -29,17 +30,17 @@ ImageDiff.getImageSize = function (filepath, cb) {
   });
 };
 ImageDiff.createDiff = function (options, cb) {
-  var diffCmd = [
+  var diffCmd = shellQuote.quote([
     'compare',
     '-verbose',
     // TODO: metric and highlight could become constructor options
-    '-metric RMSE',
-    '-highlight-color RED',
-    '-compose Src',
+    '-metric', 'RMSE',
+    '-highlight-color', 'RED',
+    '-compose', 'Src',
     options.actualPath,
     options.expectedPath,
     options.diffPath
-  ].join(' ');
+  ]);
   exec(diffCmd, function processDiffOutput (err, stdout, stderr) {
     // If we failed with no info, callback
     if (err && !stderr) {
@@ -57,10 +58,37 @@ ImageDiff.prototype = {
     var actualPath = options.actualImage;
     var expectedPath = options.expectedImage;
     var diffPath = options.diffImage;
+
+    // Assert our options are passed in
+    if (!actualPath) {
+      return process.nextTick(function () {
+        callback(new Error('`options.actualPath` was not passed to `image-diff`'));
+      });
+    }
+    if (!expectedPath) {
+      return process.nextTick(function () {
+        callback(new Error('`options.expectedPath` was not passed to `image-diff`'));
+      });
+    }
+    if (!diffPath) {
+      return process.nextTick(function () {
+        callback(new Error('`options.diffPath` was not passed to `image-diff`'));
+      });
+    }
+
     var actualTmpPath;
     var expectedTmpPath;
     var imagesAreSame;
     async.waterfall([
+      function assertActualPathExists (cb) {
+        fs.exists(actualPath, function handleActualExists (actualExists) {
+          if (actualExists) {
+            cb();
+          } else {
+            cb(new Error('`image-diff` expected "' + actualPath + '" to exist but it didn\'t'));
+          }
+        });
+      },
       function collectImageSizes (cb) {
         // Collect the images sizes
         async.map([actualPath, expectedPath], ImageDiff.getImageSize, cb);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "async": "~0.2.9",
     "gm": "~1.13.3",
     "mkdirp": "~0.3.5",
-    "tmp": "0.0.23"
+    "tmp": "0.0.23",
+    "shell-quote": "~1.4.1"
   },
   "devDependencies": {
     "mocha": "~1.11.0",


### PR DESCRIPTION
This repo was initially done in a rush and missed out on good practices. This PR starts to account for the low hanging fruit.

> This PR began while refactoring a piece of twolfson.com and falling down a hole. This repo was not at fault but did not provide good feedback.

In this PR:
- Add shell quoting for image paths
  - This prevents regressions like filepaths with spaces in them
- Assert options exist
  - Since the commands currently require all parameters, make them required
- Assert `actualImage` exists as a file
  - The parameters are required but only `actualImage` needs to exist on disk

/cc @mlmorg @Raynos 
