### PR TITLE
Assert `compare's stderr` contains 'all'

### DIFF
--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -30,6 +30,7 @@ ImageDiff.getImageSize = function (filepath, cb) {
   });
 };
 ImageDiff.createDiff = function (options, cb) {
+  // http://www.imagemagick.org/script/compare.php
   var diffCmd = shellQuote.quote([
     'compare',
     '-verbose',
@@ -47,9 +48,20 @@ ImageDiff.createDiff = function (options, cb) {
       return cb(err);
     }
 
-    // Callback with pass/fail
+    // Attempt to find variant between 'all: 0 (0)' or 'all: 40131.8 (0.612372)'
+    // DEV: According to http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=17284
+    // DEV: These values are the total square root mean square (RMSE) pixel difference across all pixels and its percentage
     // TODO: This is not very multi-lengual =(
-    return cb(null, stderr.indexOf('all: 0 (0)') !== -1);
+    var resultInfo = stderr.match(/all: (\d+\.?\d*) \((\d+\.?\d*)\)/);
+
+    // If there was no resultInfo, throw a fit
+    if (!resultInfo) {
+      return cb(new Error('Expected `image-diff\'s stderr` to contain \'all\' but received "' + stderr + '"'));
+    }
+
+    // Callback with pass/fail
+    var totalDifference = resultInfo[1];
+    return cb(null, totalDifference === '0');
   });
 };
 ImageDiff.prototype = {


### PR DESCRIPTION
As reported in #8, when `image-diff` has an internal error inside of a `compare` call, it lies and says the images are not equal. To repair this behavior, we are searching for `all` inside of `stderr` (where `compare` writes to).

In this PR:
- Add search for `all` inside of `stderr`
  - If `all` is not found, we assume it is an internal error and callback with `stderr` output
- Add helpful comments
