### PR TITLE
Deprecated project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # image-diff changelog
+2.0.0 - Deprecated project
+
 1.6.3 - Fixed word splitting in `release.sh` via @andlrc in #47
 
 1.6.2 - Updated Travis CI badge from PNG to SVG via @amilajack in #44

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # image-diff [![Build Status](https://travis-ci.org/uber/image-diff.svg?branch=master)](https://travis-ci.org/uber/image-diff)
 
+# Project deprecated
+We no longer have any active maintainers on this project and as a result have halted maintenance.
+
+As a replacement, please see alternative projects like `looks-same` and `pixelmatch`:
+
+https://github.com/gemini-testing/looks-same
+
+https://github.com/mapbox/pixelmatch
+
+--------------------
+
 Create image differential between two images
 
 This was created as part of a [visual regression][] project.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # image-diff [![Build Status](https://travis-ci.org/uber/image-diff.svg?branch=master)](https://travis-ci.org/uber/image-diff)
-
 # Project deprecated
 We no longer have any active maintainers on this project and as a result have halted maintenance.
 


### PR DESCRIPTION
In #55, we decided to deprecate this project. This PR puts the final nail in the coffin with a README deprecation notice. In this PR:

- Added deprecation notice to README
- Added CHANGELOG notes
- Closes #56 

**Release notes:**

Please run the following commands to release:

```bash
# Release project to `npm` and `git tag`
# DEV: We are intentionally using a major to avoid spamming deprecation notices to people
./release.sh 2.0.0

# Deprecate 2.0.0 version in `npm` so users get a warning on download
npm deprecate image-diff@2.0.0 "image-diff is no longer actively maintained. Please use looks-same or pixelmatch instead"
```

/cc @mlmorg 