### PR TITLE
Fix os.tmpDir DeprecationWarning and add Node 8 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "8"
   - "6"
   - "5"
   - "4"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "commander": "~2.9.0",
     "gm": "~1.21.1",
     "mkdirp": "~0.3.5",
-    "tmp": "0.0.23"
+    "tmp": "0.0.33"
   },
   "devDependencies": {
     "foundry": "~3.1.0",


### PR DESCRIPTION
This is to fix #54.